### PR TITLE
Fixes #10 - changed text references from 2024 to 2025 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Text references from 2024 to 2025 and futures prices to Nov.25 and Dec.25 for the current year [#10](https://github.com/policy-design-lab/farmdoc-frontend/issues/10)
+
+
 ## [1.8.0] - 2024-03-01
 
 ### Changed

--- a/src/app.config.js
+++ b/src/app.config.js
@@ -15,7 +15,7 @@ const farmdocApps = {
 		appDesc: "The Insurance Premiums tool shows per acre insurance premiums that farmers " +
 				"will pay for Federally-subsidized crop Insurance products. These per " +
 				"acre premiums are given for customized entries made by users that reflect individual farm cases.",
-		lastUpdated: "March 1, 2024",
+		lastUpdated: "March 1, 2025",
 		urlPath: "/premiums",
 		needsAuthentication: false
 	},

--- a/src/components/EvaluatorFarmInfo.jsx
+++ b/src/components/EvaluatorFarmInfo.jsx
@@ -67,9 +67,9 @@ class EvaluatorFarmInfo extends Component {
 
 		if (farmInfo !== null) {
 
-			let futuresDate = "Dec. 24";
+			let futuresDate = "Dec. 25";
 			if (this.props["CSCName"][0] === "Soybeans") {
-				futuresDate = "Nov. 24";
+				futuresDate = "Nov. 25";
 			}
 
 			return (
@@ -77,7 +77,7 @@ class EvaluatorFarmInfo extends Component {
 					<div style={{margin: "8px", textAlign: "right", fontSize: "larger"}}>
 						Farm TA Yield (bu/acre): <span style={{fontWeight: 700}}>{roundResults(farmInfo["trend-adj-aph"], 2)}</span><br />
 						{futuresDate} Futures Price: <span style={{fontWeight: 700}}>${roundResults(farmInfo["avg-futures-price"], 2)}</span><br />
-						RMA 2024 Projected Price: <span style={{fontWeight: 700}}>${roundResults(farmInfo["proj-price"], 2)}</span>
+						RMA 2025 Projected Price: <span style={{fontWeight: 700}}>${roundResults(farmInfo["proj-price"], 2)}</span>
 					</div>
 					<Grid container direction="row" justify="center"
 									alignItems="center" spacing={5} style={{paddingBottom: "4px"}}>

--- a/src/components/EvaluatorFooter.jsx
+++ b/src/components/EvaluatorFooter.jsx
@@ -13,7 +13,7 @@ class EvaluatorFooter extends Component {
 
 		return (
 			<div style={{padding: "4px"}}>
-				RMA 2024 Projected Price is ${this.props.projPrice} with Volatility Factor of {this.props.volFactor}. Last Updated on {this.props.lastUpdated}.
+				RMA 2025 Projected Price is ${this.props.projPrice} with Volatility Factor of {this.props.volFactor}. Last Updated on {this.props.lastUpdated}.
 			</div>
 		);
 	}

--- a/src/components/EvaluatorInputs.jsx
+++ b/src/components/EvaluatorInputs.jsx
@@ -550,7 +550,7 @@ class EvaluatorInputs extends Component {
 			<div style={{textAlign: "center"}}>
 
 				<div style={{fontSize: "1.125em", fontWeight: 600, maxWidth: "1080px", margin: "0 auto", padding: "6px 4px 0px 4px"}}>
-					Evaluator - Enter your farm information to evaluate crop insurance options for 2024
+					Evaluator - Enter your farm information to evaluate crop insurance options for 2025
 				</div>
 
 				<div style={{

--- a/src/components/EvaluatorPremiumResults.jsx
+++ b/src/components/EvaluatorPremiumResults.jsx
@@ -223,9 +223,9 @@ class EvaluatorPremiumResults extends Component {
 			let premiums = evalResultJson.policies.farm;
 			let farmInfo = evalResultJson["farm-info"];
 
-			let futuresDate = "Dec. 24";
+			let futuresDate = "Dec. 25";
 			if (this.props["CSCName"][0] === "Soybeans") {
-				futuresDate = "Nov. 24";
+				futuresDate = "Nov. 25";
 			}
 
 			let coverageLevels = Object.keys(premiums);
@@ -392,7 +392,7 @@ class EvaluatorPremiumResults extends Component {
 							<div style={{margin: "8px", textAlign: "right", fontSize: "larger"}}>
 								Farm TA Yield (bu/acre): <span style={{fontWeight: 700}}>{roundResults(farmInfo["trend-adj-aph"], 2)}</span><br />
 								{futuresDate} Futures Price: <span style={{fontWeight: 700}}>${roundResults(farmInfo["avg-futures-price"], 2)}</span><br />
-								RMA 2024 Projected Price: <span style={{fontWeight: 700}}>${roundResults(farmInfo["proj-price"], 2)}</span>
+								RMA 2025 Projected Price: <span style={{fontWeight: 700}}>${roundResults(farmInfo["proj-price"], 2)}</span>
 							</div>
 						</Grid>
 					</Grid>

--- a/src/components/EvaluatorRiskResults.jsx
+++ b/src/components/EvaluatorRiskResults.jsx
@@ -311,9 +311,9 @@ class EvaluatorRiskResults extends Component {
 			let premiums = evalResultJson.policies.farm;
 			let farmInfo = evalResultJson["farm-info"];
 
-			let futuresDate = "Dec. 24";
+			let futuresDate = "Dec. 25";
 			if (this.props["CSCName"][0] === "Soybeans") {
-				futuresDate = "Nov. 24";
+				futuresDate = "Nov. 25";
 			}
 
 			let coverageLevels = Object.keys(premiums);
@@ -564,7 +564,7 @@ class EvaluatorRiskResults extends Component {
 							<div style={{marginRight: "10px", marginTop: "10px", textAlign: "right", fontSize: "larger"}}>
 								Farm TA Yield (bu/acre): <span style={{fontWeight: 700}}>{roundResults(farmInfo["trend-adj-aph"], 2)}</span><br />
 								{futuresDate} Futures Price: <span style={{fontWeight: 700}}>${roundResults(farmInfo["avg-futures-price"], 2)}</span><br />
-								RMA 2024 Projected Price: <span style={{fontWeight: 700}}>${roundResults(farmInfo["proj-price"], 2)}</span>
+								RMA 2025 Projected Price: <span style={{fontWeight: 700}}>${roundResults(farmInfo["proj-price"], 2)}</span>
 							</div>
 						</Grid>
 					</Grid>

--- a/src/components/PremiumCalculator.jsx
+++ b/src/components/PremiumCalculator.jsx
@@ -366,7 +366,7 @@ class PremiumCalculator extends Component {
 				this.setState({riskClasses: data.riskClasses});
 				this.setState({projectedPrice: roundResults(data.comboProjPrice, 2)});
 				this.setState({volFactor: roundResults(data.comboVol, 2)});
-				this.setState({futuresUpdated: `RMA 2024 Projected Price is $${ roundResults(data.comboProjPrice, 2)} with Volatility Factor of
+				this.setState({futuresUpdated: `RMA 2025 Projected Price is $${ roundResults(data.comboProjPrice, 2)} with Volatility Factor of
 				 ${ roundResults(data.comboVol, 2)}. Last Updated on ${ data.dateUpdated}.`});
 
 				//TODO: Confirm with PIs if these defaults will be good for all counties
@@ -725,7 +725,7 @@ class PremiumCalculator extends Component {
 			<div style={{textAlign: "center"}}>
 
 				<div style={{marginTop: "12px", fontSize: "1.125em", fontWeight: 600}}>
-					Enter your farm information to generate crop insurance quotes for 2024
+					Enter your farm information to generate crop insurance quotes for 2025
 				</div>
 
 				<div style={{


### PR DESCRIPTION
Updated text references from 2024 to 2025 and updated the futures prices to fetch Nov. 25 fo Soybean and Dec. 25 for Corn in preparation for this years release.