### PR TITLE
#23: add footer to the new insurance evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Create the new ARC/PLC calculator [#18](https://github.com/policy-design-lab/farmdoc-frontend/issues/18)
 - Change the insurance evaluator to use whole number for the FARM TA Yield [#20](https://github.com/policy-design-lab/farmdoc-frontend/issues/20)
 - Change the insurance evaluator to switch the Net Revenue from var1 to var5 in the tooltip and Add “Payment Frequency (%)” to insurance summary card [#22](https://github.com/policy-design-lab/farmdoc-frontend/issues/22)
+- Add “Simulated payments and benefits do not include prevent planting.” as the footer for the new insurance evaluator [#23](https://github.com/policy-design-lab/farmdoc-frontend/issues/23)
 
 ## [1.9.0] - 2025-03-01
 - Text references from 2024 to 2025 and futures prices to Nov.25 and Dec.25 for the current year [#10](https://github.com/policy-design-lab/farmdoc-frontend/issues/10)

--- a/src/components/NewEvaluator/NewEvaluatorDashboard.jsx
+++ b/src/components/NewEvaluator/NewEvaluatorDashboard.jsx
@@ -18,7 +18,7 @@ class NewEvaluatorDashboard extends Component {
 		this.setState({
 			compareMode: isCompareMode,
 			scoEnabled: scoEnabled || false,
-			ecoLevel: ecoLevel || "off"
+			ecoLevel: ecoLevel || "off",
 		});
 	};
 
@@ -62,7 +62,9 @@ class NewEvaluatorDashboard extends Component {
 				const scenarioKey = getScenarioKey(scoEnabled, ecoLevel);
 				const policyKey = `${insurancePlan}-${insUnit}`;
 				baseSelection =
-					policies?.farm?.[scenarioKey]?.[coverageLevel.toString()]?.[policyKey] || {};
+					policies?.farm?.[scenarioKey]?.[coverageLevel.toString()]?.[
+						policyKey
+					] || {};
 			}
 			catch (e) {
 				console.error("Error parsing evaluator results:", e);
@@ -134,6 +136,19 @@ class NewEvaluatorDashboard extends Component {
 										<NewEvaluatorResults
 											onCompareModeChange={this.handleCompareModeChange}
 										/>
+										<div
+											style={{
+												textAlign: "center",
+												marginTop: "1.5rem",
+												color: "#8A9BA4",
+												fontSize: "0.75rem",
+												fontStyle: "italic",
+												lineHeight: "1.25rem",
+											}}
+										>
+											Simulated payments and benefits do not include prevent
+											planting.
+										</div>
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
This PR addresses #23. It adds a footer to the new insurance evaluator as requested by the collaborator via email. The footer appears at the end of the Result Panel (i.e., it only displays in non-compare mode, since users may need to add insurance cards in compare mode and the footer could overlap with new cards). I can make it stick to the website footer if this is better.

# How to Test

Navigate to the new insurance evaluator and you should see the corresponding footer.
<img width="2790" height="1784" alt="Screenshot 2026-02-10 at 11 24 07 AM" src="https://github.com/user-attachments/assets/38b3e30b-2a0a-42d7-a5d8-c7a0517f8ad3" />
