### PR TITLE
#27: update the tooltip to use api data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Changed
-
-- Upgrade the project's node version to 22 and python to 3 [#10](https://github.com/policy-design-lab/farmdoc-frontend/issues/10)
-- Change the insurance evaluator to switch the Net Revenue from var1 to var5 in the tooltip and Add “Payment Frequency (%)” to insurance summary card [#22](https://github.com/policy-design-lab/farmdoc-frontend/issues/22)
-
 ### Added
 
 - Create the new insurance evaluator [#17](https://github.com/policy-design-lab/farmdoc-frontend/issues/17)
@@ -18,6 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Change the insurance evaluator to use whole number for the FARM TA Yield [#20](https://github.com/policy-design-lab/farmdoc-frontend/issues/20)
 - Add “Simulated payments and benefits do not include prevent planting.” as the footer for the new insurance evaluator [#23](https://github.com/policy-design-lab/farmdoc-frontend/issues/23)
 - Add the farmdoc article and YouTube video for the documentation of the new insurance evaluator [#25](https://github.com/policy-design-lab/farmdoc-frontend/issues/25)
+
+### Changed
+
+- Upgrade the project's node version to 22 and python to 3 [#10](https://github.com/policy-design-lab/farmdoc-frontend/issues/10)
+- Change the insurance evaluator to switch the Net Revenue from var1 to var5 in the tooltip and Add “Payment Frequency (%)” to insurance summary card [#22](https://github.com/policy-design-lab/farmdoc-frontend/issues/22)
+- Change the tooltip for Yield & Price info pop-up in the insurance evaluator to use the dynamic value from API [#27](https://github.com/policy-design-lab/farmdoc-frontend/issues/27)
 
 ## [1.9.0] - 2025-03-01
 - Text references from 2024 to 2025 and futures prices to Nov.25 and Dec.25 for the current year [#10](https://github.com/policy-design-lab/farmdoc-frontend/issues/10)

--- a/src/components/NewEvaluator/YieldPriceInfo.jsx
+++ b/src/components/NewEvaluator/YieldPriceInfo.jsx
@@ -43,11 +43,14 @@ const YieldPriceInfo = ({
 		if (cropLower === "soybean" || cropLower === "soybeans") {
 			monthLabel = "Nov";
 		}
-
+		const futuresLastUpdated = farmInfo?.["futures-last-updated"];
+		if (futuresLastUpdated) {
+			return `${monthLabel} 26 Future Price (as of ${futuresLastUpdated})`;
+		}
 		if (currentYear === 2026 && currentMonth > 10) {
 			return `${monthLabel} 26 Future Price (average of October 2026)`;
 		}
-		return `${monthLabel} 26 Future Price (as of Jan 2026)`;
+		return `${monthLabel} 26 Future Price (as of Jan 2026)`; // theoretically not used
 	};
 
 	const getProjectedPriceValue = () => {


### PR DESCRIPTION
This PR addresses #27. It replaces the "as of Jan 2026" in the tooltip of the Yield & Price info section in the insurance evaluator app with the API value.

## How to Test
Run the app and navigate to the insurance evaluator. You shoudl see the tooltip has been updated in both original view and compare mode:
<img width="728" height="189" alt="Screenshot 2026-02-26 at 3 42 27 PM" src="https://github.com/user-attachments/assets/470214c8-df6e-4dd1-a4ea-75eb077e2db2" />
